### PR TITLE
Rackinect now only requires actually needed parts of vigracket, thus …

### DIFF
--- a/examples.rkt
+++ b/examples.rkt
@@ -1,6 +1,9 @@
 #lang racket
 
-(require vigracket)
+(require vigracket/helpers
+         vigracket/convert
+         vigracket/imgproc
+         vigracket/morphology)
 (require rackinect)
 
 (require (rename-in 2htdp/image

--- a/grab.rkt
+++ b/grab.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require vigracket)
+(require vigracket/helpers)
 
 (require rackinect/config)
 


### PR DESCRIPTION
…removing racket/gui from the requirements. racket/gui proved to be troublesome if required multiple times while using racket/place